### PR TITLE
Make uploads persistent

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,14 @@ import uuid
 import json
 
 app = Flask(__name__)
-app.config['UPLOAD_FOLDER'] = 'static/uploads/'
+
+# Allow customization of where uploads and results are stored.
+app.config['UPLOAD_FOLDER'] = os.getenv('UPLOAD_FOLDER', 'static/uploads/')
+RESULTS_PATH = os.getenv('RESULTS_PATH', 'results.json')
+
+# Ensure required directories exist so that Docker volume mounts work as expected.
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+os.makedirs(os.path.dirname(RESULTS_PATH) or '.', exist_ok=True)
 
 # Load TFLite model and allocate tensors
 interpreter = tf.lite.Interpreter(model_path="model.tflite")
@@ -31,7 +38,7 @@ def preprocess_image(image_path):
 
 @app.route('/', methods=['GET', 'POST'])
 def upload_and_classify():
-    results_path = "results.json"
+    results_path = RESULTS_PATH
     results = {}
 
     # Load existing results if any

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - "8080:5000"
     volumes:
       - "${UPLOADS_PATH:-/var/lib/phineas/static/uploads}:/app/static/uploads"
+      - "${DATA_PATH:-/var/lib/phineas/data}:/app/data"
+    environment:
+      - RESULTS_PATH=/app/data/results.json
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000"]


### PR DESCRIPTION
## Summary
- allow customizing upload and results paths
- ensure folders exist on startup
- map results data to a docker volume via docker-compose

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684dbe924df0832c9a4c1e4cc70198a6