### PR TITLE
Update configuration via environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,7 @@
 # Import the env in Portainer, or remove it
 # This is just an example
 UPLOADS_PATH=/mnt/docker/phineasandferb/static/uploads
+MODEL_PATH=model.tflite
+RESULTS_PATH=results.json
+FLASK_PORT=5000
+FLASK_DEBUG=true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 Personal experience with Vision AI Classification.
 Trained on my two cats, Phineas and Ferb.
 Goal is to make an universal package that people can use to train their own model, make a connection with input images (Share, MQTT, Frigate, ??) and classify the feeds.
+
+## Environment Variables
+
+- `MODEL_PATH`: path to the TFLite model (default `model.tflite`)
+- `RESULTS_PATH`: path to the JSON file storing predictions (default `results.json`)
+- `FLASK_PORT`: port used by the Flask server (default `5000`)
+- `FLASK_DEBUG`: set to `true` to enable debug mode
+

--- a/app.py
+++ b/app.py
@@ -9,8 +9,14 @@ import json
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = 'static/uploads/'
 
+# Paths and runtime options from environment variables
+MODEL_PATH = os.environ.get("MODEL_PATH", "model.tflite")
+RESULTS_PATH = os.environ.get("RESULTS_PATH", "results.json")
+FLASK_PORT = int(os.environ.get("FLASK_PORT", 5000))
+FLASK_DEBUG = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+
 # Load TFLite model and allocate tensors
-interpreter = tf.lite.Interpreter(model_path="model.tflite")
+interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
 interpreter.allocate_tensors()
 
 # Get input and output tensors
@@ -31,7 +37,7 @@ def preprocess_image(image_path):
 
 @app.route('/', methods=['GET', 'POST'])
 def upload_and_classify():
-    results_path = "results.json"
+    results_path = RESULTS_PATH
     results = {}
 
     # Load existing results if any
@@ -69,4 +75,8 @@ def upload_and_classify():
 
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(
+        debug=os.environ.get("FLASK_DEBUG", "false").lower() == "true",
+        host='0.0.0.0',
+        port=int(os.environ.get("FLASK_PORT", 5000))
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     container_name: image-classifier
     ports:
-      - "8080:5000"
+      - "${FLASK_PORT:-5000}:${FLASK_PORT:-5000}"
     volumes:
       - "${UPLOADS_PATH:-/var/lib/phineas/static/uploads}:/app/static/uploads"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- make model/results paths and Flask options configurable
- expose Flask port via docker-compose
- document environment variables

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684e15d3175c832ca85b53e4209bb838