### PR TITLE
Add curl to dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     build-essential \
     libjpeg-dev \
+    curl \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- add `curl` to apt-get packages in the Dockerfile

## Testing
- `docker build -t test-image .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ec6cc61a0832c95ff61b852964fc5