### PR TITLE
Add model/results volume mappings

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,9 @@
 # Import the env in Portainer, or remove it
 # This is just an example
 UPLOADS_PATH=/mnt/docker/phineasandferb/static/uploads
-MODEL_PATH=model.tflite
-RESULTS_PATH=results.json
+# Path to the model inside the container
+MODEL_PATH=/app/model.tflite
+# Path to the results file inside the container
+RESULTS_PATH=/app/results.json
 FLASK_PORT=5000
 FLASK_DEBUG=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - "${FLASK_PORT:-5000}:5000"
     volumes:
       - "${UPLOADS_PATH:-/var/lib/phineas/static/uploads}:/app/static/uploads"
+      - "/path/on/host/model.tflite:${MODEL_PATH:-/app/model.tflite}"
+      - "/path/on/host/results.json:${RESULTS_PATH:-/app/results.json}"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000"]


### PR DESCRIPTION
## Summary
- mount model and results files through docker-compose
- point MODEL_PATH and RESULTS_PATH to mounted locations

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ec74df7e0832cabc5fa4705863bfc