### PR TITLE
Use direct paths for docker volumes

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,4 @@
-# Set here a custom location for the data
-# Import the env in Portainer, or remove it
-# This is just an example
-UPLOADS_PATH=/mnt/docker/phineasandferb/static/uploads
+# Example configuration for the container
 # Path to the model inside the container
 MODEL_PATH=/app/model.tflite
 # Path to the results file inside the container

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Goal is to make an universal package that people can use to train their own mode
 The application can be tuned through environment variables. These can either be
 set in your shell, passed via `docker-compose`, or stored in a `.env` file.
 
-- `MODEL_PATH` - path to the TFLite model (default `model.tflite`)
-- `RESULTS_PATH` - path to the JSON file storing predictions (default
-  `results.json`)
+- `MODEL_PATH` - path to the TFLite model inside the container (default `model.tflite`)
+- `RESULTS_PATH` - path inside the container storing predictions (default `results.json`)
 - `FLASK_PORT` - port used by the Flask server (default `5000`)
 - `FLASK_DEBUG` - set to `true` to enable debug mode
-- `UPLOADS_PATH` - directory on the host used to persist uploaded files (default
-  `/var/lib/phineas/static/uploads`)
+
+Host paths for uploads, the model and results are configured directly in
+`docker-compose.yml`.
 
 ### Example
 
@@ -24,7 +24,6 @@ FLASK_PORT=5000
 FLASK_DEBUG=true
 MODEL_PATH=model.tflite
 RESULTS_PATH=results.json
-UPLOADS_PATH=/tmp/uploads
 ```
 
 Then start the service with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
     ports:
       - "${FLASK_PORT:-5000}:5000"
     volumes:
-      - "${UPLOADS_PATH:-/var/lib/phineas/static/uploads}:/app/static/uploads"
-      - "/path/on/host/model.tflite:${MODEL_PATH:-/app/model.tflite}"
-      - "/path/on/host/results.json:${RESULTS_PATH:-/app/results.json}"
+      - "/mnt/docker/phineasandferb/static/uploads:/app/static/uploads"
+      - "/mnt/docker/phineasandferb/model.tflite:/app/model.tflite"
+      - "/mnt/docker/phineasandferb/results.json:/app/results.json"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000"]


### PR DESCRIPTION
## Summary
- hardcode host paths in `docker-compose.yml` instead of relying on env vars
- update README to mention volume locations are configured in compose file
- clean up sample `.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed2d27cd8832c96714282df97bd3d