### PR TITLE
Add startup setup script for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy app source
 COPY . .
 COPY templates/ templates/
-CMD ["python", "app.py"]
+# keep a copy of the bundled model so volumes can't overwrite it
+RUN cp model.tflite default_model.tflite
+
+# run setup script before launching the application
+CMD ["bash", "-c", "python setup_paths.py && python app.py"]

--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ Then start the service with:
 docker-compose up
 ```
 
+### Startup behavior
+
+The container runs `setup_paths.py` before launching the Flask app. This script
+ensures `/app/static/uploads`, `/app/model.tflite` and `/app/results.json`
+exist. If the mounted model file is empty, the bundled default model is copied
+so the service has a usable model on first start.
+

--- a/setup_paths.py
+++ b/setup_paths.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+import shutil
+
+UPLOAD_DIR = Path('/app/static/uploads')
+MODEL_PATH = Path('/app/model.tflite')
+RESULTS_PATH = Path('/app/results.json')
+DEFAULT_MODEL = Path('/app/default_model.tflite')
+
+# Ensure upload directory exists
+UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+# Ensure results file exists
+if not RESULTS_PATH.exists():
+    RESULTS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    RESULTS_PATH.write_text('{}')
+
+# Ensure model file exists and is not empty
+if not MODEL_PATH.exists() or MODEL_PATH.stat().st_size == 0:
+    MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if DEFAULT_MODEL.exists():
+        shutil.copy(DEFAULT_MODEL, MODEL_PATH)


### PR DESCRIPTION
## Summary
- add `setup_paths.py` that ensures required paths exist and copies the default model
- keep a copy of the bundled model in Docker image
- run the setup script before launching `app.py`
- document the startup behaviour in `README.md`

## Testing
- `python -m py_compile setup_paths.py`
- `python -m py_compile app.py setup_paths.py`


------
https://chatgpt.com/codex/tasks/task_e_684edb1c41b4832cabdfc715a79f854c