### PR TITLE
Support custom paths for model and results

### DIFF
--- a/setup_paths.py
+++ b/setup_paths.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import shutil
 
 UPLOAD_DIR = Path('/app/static/uploads')
-MODEL_PATH = Path('/app/model.tflite')
-RESULTS_PATH = Path('/app/results.json')
+MODEL_PATH = Path(os.environ.get('MODEL_PATH', '/app/model.tflite'))
+RESULTS_PATH = Path(os.environ.get('RESULTS_PATH', '/app/results.json'))
 DEFAULT_MODEL = Path('/app/default_model.tflite')
 
 # Ensure upload directory exists


### PR DESCRIPTION
## Summary
- read `MODEL_PATH` and `RESULTS_PATH` from environment variables in `setup_paths.py`

## Testing
- `python -m py_compile setup_paths.py`

------
https://chatgpt.com/codex/tasks/task_e_684eef26496c832c9e8f027c0a5857f8