### PR TITLE
Use prebuilt docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ ensures `/app/static/uploads`, `/app/model.tflite` and `/app/results.json`
 exist. If the mounted model file is empty, the bundled default model is copied
 so the service has a usable model on first start.
 
+## Docker image
+
+The application is published as `vries2k/phineasorferborelse:1.0` and the
+included `docker-compose.yml` uses this image by default. Adjust any of the
+paths or ports in the compose file if they do not fit your environment.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,25 @@ version: '3.9'
 
 services:
   image-classifier:
-    build: .
+    image: vries2k/phineasorferborelse:1.0
     container_name: image-classifier
     environment:
-      MODEL_PATH: "${MODEL_PATH:-/app/model.tflite}"
-      RESULTS_PATH: "${RESULTS_PATH:-/app/results.json}"
-      FLASK_DEBUG: "${FLASK_DEBUG:-false}"
+      # Path to the TFLite model inside the container
+      MODEL_PATH: /app/model.tflite
+      # Path to store prediction results
+      RESULTS_PATH: /app/results.json
+      # Set to "true" to enable Flask debug mode
+      FLASK_DEBUG: "false"
     ports:
-      - "${FLASK_PORT:-5000}:5000"
+      # Change the host port if needed
+      - "5000:5000"
     volumes:
-      - "/mnt/docker/phineasandferb/static/uploads:/app/static/uploads"
-      - "/mnt/docker/phineasandferb/model.tflite:/app/model.tflite"
-      - "/mnt/docker/phineasandferb/results.json:/app/results.json"
+      # Uploaded images will be stored here
+      - /mnt/docker/phineasandferb/static/uploads:/app/static/uploads
+      # Model file location on the host
+      - /mnt/docker/phineasandferb/model.tflite:/app/model.tflite
+      # Results file location on the host
+      - /mnt/docker/phineasandferb/results.json:/app/results.json
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000"]


### PR DESCRIPTION
## Summary
- source the prebuilt image `vries2k/phineasorferborelse:1.0`
- inline default environment variables in compose file with comments
- document the published image in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f20ec7624832caef163c2bdc15795